### PR TITLE
ENH: build from docker image python:3.6-alpine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,5 +23,5 @@ docs:
 	docker container run \
 		-it --rm \
 		-v $(MOUNT_DIR):/usr/src/$(PROJECT) \
-		python_$(PROJECT) \
-			/bin/bash -c "cd docs; make html"
+		-w /usr/src/$(PROJECT)/docs \
+		python_$(PROJECT) make html

--- a/docker/python-Dockerfile
+++ b/docker/python-Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.6
+FROM python:3.6-alpine
+
+RUN apk add --update alpine-sdk
 
 WORKDIR /usr/src/chrysalis
 


### PR DESCRIPTION
The docker image of python:3.6 was 1.04 GB and now with Alpine is 353 MB.